### PR TITLE
Add CC BY-SA 2.0 attribution.

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -200,7 +200,10 @@ write_map(pqxx::work &w,
     writer.start("osm");
     writer.attribute("version", string("0.6"));
     writer.attribute("generator", string(PACKAGE_STRING));
-    
+    writer.attribute("copyright",  string("OpenStreetMap and contributors"));
+    writer.attribute("attribution", string("http://www.openstreetmap.org/copyright/"));
+    writer.attribute("license", string("http://creativecommons.org/licenses/by-sa/2.0/"));
+
     // bounds element, which seems to be standard in the 
     // main map call.
     writer.start("bounds");


### PR DESCRIPTION
Add CC BY-SA 2.0 XML attributes for moment, in preparation for ODbL 1.0 attributes.
